### PR TITLE
Task session id from firestore

### DIFF
--- a/qwiz-app/backend/app/api/sessions.py
+++ b/qwiz-app/backend/app/api/sessions.py
@@ -4,6 +4,11 @@ import json
 import uuid
 from datetime import datetime, timedelta, timezone
 
+### temporary imports
+import random
+import string
+### end temporary imports
+
 import requests
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 
@@ -304,4 +309,12 @@ async def end_session(session_id: str):
 
 @router.get("/api/session_id/get")
 async def get_session_id():
-    return {"message": "Hello from the Get Session ID endpoint"}
+
+    ### temporary code generation functionality (moved from frontend to backend to test connection), to be updated!
+    # Define the characters to choose from (Upper case alphabet + numbers)
+    characters = string.ascii_uppercase + string.digits
+    
+    # Generate a random 4 character code
+    code = ''.join(random.choice(characters) for _ in range(4))
+
+    return {"code": code}

--- a/qwiz-app/backend/app/api/sessions.py
+++ b/qwiz-app/backend/app/api/sessions.py
@@ -301,3 +301,7 @@ async def end_session(session_id: str):
     except Exception as e:
         print(f"Error ending session: {e}")
         raise HTTPException(status_code=500, detail="Error ending session")
+
+@router.get("/api/session_id/get")
+async def get_session_id():
+    return {"message": "Hello from the Get Session ID endpoint"}

--- a/qwiz-app/backend/app/main.py
+++ b/qwiz-app/backend/app/main.py
@@ -35,6 +35,11 @@ def _startup_event():
 async def root():
     return {"status": "The Qwiz App backend is running"}
 
+# --- Root Endpoints (App Functions) ---
+@app.get("/api/session_id/get")
+async def root():
+    return {"message": "Hello from the Get Session ID endpoint"}
+
 # --- Uvicorn Server Setup ---
 # The entry point for running the application locally.
 if __name__ == "__main__":

--- a/qwiz-app/backend/app/main.py
+++ b/qwiz-app/backend/app/main.py
@@ -35,11 +35,6 @@ def _startup_event():
 async def root():
     return {"status": "The Qwiz App backend is running"}
 
-# --- Root Endpoints (App Functions) ---
-@app.get("/api/session_id/get")
-async def root():
-    return {"message": "Hello from the Get Session ID endpoint"}
-
 # --- Uvicorn Server Setup ---
 # The entry point for running the application locally.
 if __name__ == "__main__":

--- a/qwiz-app/frontend/src/app/lecturer/page.tsx
+++ b/qwiz-app/frontend/src/app/lecturer/page.tsx
@@ -22,12 +22,35 @@ export default function LecturerStartPage() {
   useEffect(() => {
     async function getCode() {
       try {
-        const response = await fetch('http://localhost:8080/api/session_id/get'); 
+        ////// version 1 of getting code (code generated in backend)
+        // const response = await fetch('http://localhost:8080/api/session_id/get');
+
+        ////// version 2 of getting code (create a session + return the data)
+        const response = await fetch('http://localhost:8080/start-session', {
+          method: 'POST', // declare as a post method
+          headers: {
+            'Content-Type': 'application/json', // declares data in the body being sent through as a JSON object
+          },
+          body: JSON.stringify({
+            // Add the data the backend expects here - temporarily hardcoded
+            lecturer_name: "Test Lecturer",
+            course_name: "Test Course",
+            question_interval_seconds: 300,
+            answer_time_seconds: 60,
+          }),
+        }); 
+
         if (!response.ok) {
           throw new Error('Failed to fetch code');
         }
         const data = await response.json();
-        setCode(data.code); // Access the 'code' key from the JSON object sent from the backend
+
+        ////// version 1 of getting code from response data
+        // setCode(data.code); // Access the 'code' key from the returned JSON object as code
+
+        ////// version 2 of getting code from response data
+        setCode(data.sessionId); // Access the 'sessionID' key from the returned JSON object as code
+
       } catch (error) {
         console.error("Error fetching code:", error);
       }

--- a/qwiz-app/frontend/src/app/lecturer/page.tsx
+++ b/qwiz-app/frontend/src/app/lecturer/page.tsx
@@ -1,22 +1,39 @@
 // Lecturer start page// 
 "use client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardBody, Button } from "@/components/ui";
 import Link from "next/link";
 import { useToast } from "@/components/Toast";
 
-function makeCode() {
-  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-  let c = "";
-  for (let i = 0; i < 4; i++) c += chars[Math.floor(Math.random() * chars.length)];
-  return c;
-}
+// function makeCode() {
+//   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+//   let c = "";
+//   for (let i = 0; i < 4; i++) c += chars[Math.floor(Math.random() * chars.length)];
+//   return c;
+// }
 
 export default function LecturerStartPage() {
   const router = useRouter();
-  const [code] = useState(makeCode());
+  // const [code] = useState(makeCode());
+  const [code, setCode] = useState("");
   const { showToast } = useToast();
+
+  useEffect(() => {
+    async function getCode() {
+      try {
+        const response = await fetch('http://localhost:8080/api/session_id/get'); 
+        if (!response.ok) {
+          throw new Error('Failed to fetch code');
+        }
+        const data = await response.json();
+        setCode(data.code); // Access the 'code' key from the JSON object sent from the backend
+      } catch (error) {
+        console.error("Error fetching code:", error);
+      }
+    }
+    getCode();
+  }, []);
 
   const handleCopy = async () => {
     try {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this pull request (PR) -->
Connect the frontend and backend together by creating a session in firebase (linked to backend) and display the session id returned as the code for the session. There is hard coded things related to the data being sent when sending a request to create a session - that will be updated once further functionality is merged in//created related to it.

**Related to:** [Trello Ticket Connecting front-end code to session ID created in Firestore](https://trello.com/c/uAXPlfnT/29-connecting-front-end-code-to-session-id-created-in-firestore)

## Changes Made

<!-- List the main changes made in this PR -->
- Connected the front end and back end to create a new session when navigating to the lecturer start session page and return the session id to display as the code on the front end

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests
- [x] Manual tests

## Reviewer's Checklist

- [ ] Code is well-documented, especially in complex areas.
- [ ] Code follows the established style guidelines.
- [ ] All new code is covered by tests.
- [ ] Changes are fully working as intended.

## Additional Notes

<!-- Add any additional notes or context for reviewers -->
